### PR TITLE
WIP interpreter tests

### DIFF
--- a/packages/bitcore-lib-doge/lib/crypto/signature.js
+++ b/packages/bitcore-lib-doge/lib/crypto/signature.js
@@ -79,7 +79,7 @@ Signature.fromTxFormat = function(buf) {
 };
 
 Signature.fromString = function(str) {
-  var buf = new Buffer(str, 'hex');
+  var buf = Buffer.from(str, 'hex');
   return Signature.fromDER(buf);
 };
 
@@ -154,7 +154,7 @@ Signature.prototype.toCompact = function(i, compressed) {
   if (compressed === false) {
     val = val - 4;
   }
-  var b1 = new Buffer([val]);
+  var b1 = Buffer.from([val]);
   var b2 = this.r.toBuffer({
     size: 32
   });
@@ -171,8 +171,8 @@ Signature.prototype.toBuffer = Signature.prototype.toDER = function() {
   var rneg = rnbuf[0] & 0x80 ? true : false;
   var sneg = snbuf[0] & 0x80 ? true : false;
 
-  var rbuf = rneg ? Buffer.concat([new Buffer([0x00]), rnbuf]) : rnbuf;
-  var sbuf = sneg ? Buffer.concat([new Buffer([0x00]), snbuf]) : snbuf;
+  var rbuf = rneg ? Buffer.concat([Buffer.from([0x00]), rnbuf]) : rnbuf;
+  var sbuf = sneg ? Buffer.concat([Buffer.from([0x00]), snbuf]) : snbuf;
 
   var rlength = rbuf.length;
   var slength = sbuf.length;
@@ -181,7 +181,7 @@ Signature.prototype.toBuffer = Signature.prototype.toDER = function() {
   var sheader = 0x02;
   var header = 0x30;
 
-  var der = Buffer.concat([new Buffer([header, length, rheader, rlength]), rbuf, new Buffer([sheader, slength]), sbuf]);
+  var der = Buffer.concat([Buffer.from([header, length, rheader, rlength]), rbuf, Buffer.from([sheader, slength]), sbuf]);
   return der;
 };
 
@@ -299,7 +299,7 @@ Signature.prototype.hasDefinedHashtype = function() {
 
 Signature.prototype.toTxFormat = function() {
   var derbuf = this.toDER();
-  var buf = new Buffer(1);
+  var buf = Buffer.alloc(1);
   buf.writeUInt8(this.nhashtype, 0);
   return Buffer.concat([derbuf, buf]);
 };

--- a/packages/bitcore-lib-doge/lib/transaction/sighashwitness.js
+++ b/packages/bitcore-lib-doge/lib/transaction/sighashwitness.js
@@ -28,8 +28,8 @@ var _ = require('lodash');
 var sighash = function sighash(transaction, sighashType, inputNumber, scriptCode, satoshisBuffer) {
   /* jshint maxstatements: 50 */
 
-  var hashPrevouts;
-  var hashSequence;
+  var hashPrevouts = Buffer.alloc(32);
+  var hashSequence = Buffer.alloc(32);
   var hashOutputs;
 
   if (!(sighashType & Signature.SIGHASH_ANYONECANPAY)) {

--- a/packages/bitcore-lib-doge/test/script/interpreter.js
+++ b/packages/bitcore-lib-doge/test/script/interpreter.js
@@ -11,8 +11,7 @@ var BufferWriter = bitcore.encoding.BufferWriter;
 var Opcode = bitcore.Opcode;
 var _ = require('lodash');
 
-var script_valid = require('../data/bitcoind/script_valid');
-var script_invalid = require('../data/bitcoind/script_invalid');
+var script_tests = require('../data/bitcoind/script_tests');
 var tx_valid = require('../data/bitcoind/tx_valid');
 var tx_invalid = require('../data/bitcoind/tx_invalid');
 
@@ -31,10 +30,10 @@ Script.fromBitcoindString = function(str) {
     var tbuf;
     if (token[0] === '0' && token[1] === 'x') {
       var hex = token.slice(2);
-      bw.write(new Buffer(hex, 'hex'));
+      bw.write(Buffer.from(hex, 'hex'));
     } else if (token[0] === '\'') {
       var tstr = token.slice(1, token.length - 1);
-      var cbuf = new Buffer(tstr);
+      var cbuf = Buffer.from(tstr);
       tbuf = Script().add(cbuf).toBuffer();
       bw.write(tbuf);
     } else if (typeof Opcode['OP_' + token] !== 'undefined') {
@@ -81,7 +80,7 @@ describe('Interpreter', function() {
       Interpreter.castToBool(new BN(0).toSM({
         endian: 'little'
       })).should.equal(false);
-      Interpreter.castToBool(new Buffer('0080', 'hex')).should.equal(false); //negative 0
+      Interpreter.castToBool(Buffer.from('0080', 'hex')).should.equal(false); //negative 0
       Interpreter.castToBool(new BN(1).toSM({
         endian: 'little'
       })).should.equal(true);
@@ -89,7 +88,7 @@ describe('Interpreter', function() {
         endian: 'little'
       })).should.equal(true);
 
-      var buf = new Buffer('00', 'hex');
+      var buf = Buffer.from('00', 'hex');
       var bool = BN.fromSM(buf, {
         endian: 'little'
       }).cmp(BN.Zero) !== 0;
@@ -131,12 +130,12 @@ describe('Interpreter', function() {
       var toAddress = 'DS1csbTjWURfExDwVKg12p9c8Vha6CGsG3';
       var scriptPubkey = Script.buildPublicKeyHashOut(fromAddress);
       var utxo = {
-        "txid" : "fd1d3baa6c7f35fc8f176a9fb180487ddf462a27c1707d24af0100fed41d5221",
-        "vout" : 0,
-        "address" : "DE1wEbm9D6JqEhqGtyD52BkHQmQ5N18J84",
-        "scriptPubKey" : "76a914615e740f1219a7b7b84530accdf6722bb255e5cf88ac",
-        "amount" : 75.000
-    };
+        address: fromAddress,
+        txId: 'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458',
+        outputIndex: 0,
+        script: scriptPubkey,
+        satoshis: 100000
+      };
       var tx = new Transaction()
         .from(utxo)
         .to(toAddress, 100000)
@@ -239,7 +238,7 @@ describe('Interpreter', function() {
     }));
     credtx.addOutput(new Transaction.Output({
       script: scriptPubkey,
-      satoshis: amount,
+      satoshis: amount
     }));
     var idbuf = credtx.id;
 
@@ -253,7 +252,7 @@ describe('Interpreter', function() {
     }));
     spendtx.addOutput(new Transaction.Output({
       script: new Script(),
-      satoshis: amount,
+      satoshis: amount
     }));
 
 
@@ -263,17 +262,13 @@ describe('Interpreter', function() {
   };
 
   describe('bitcoind script evaluation fixtures', function() {
-    var testAllFixtures = function(set, expected) {
+    var testAllFixtures = function(set) {
       var c = 0;
       set.forEach(function(vector) {
         if (vector.length === 1) {
           return;
         }
         c++;
-
-        
-
-        var witness, amount;
 
         var witness, amount;
         if (_.isArray(vector[0])) {
@@ -286,36 +281,47 @@ describe('Interpreter', function() {
           return;
         }
 
-        var descstr = vector[3];
         var fullScriptString = vector[0] + ' ' + vector[1];
+        var expected = vector[3] == 'OK';
+        var descstr = vector[4];
+
         var comment = descstr ? (' (' + descstr + ')') : '';
-        it('should pass script_' + (expected ? '' : 'in') + 'valid ' +
+        it('should ' + vector[3] + ' script_tests ' +
           'vector #' + c + ': ' + fullScriptString + comment,
           function() {
             testFixture(vector, expected, witness, amount);
           });
       });
     };
-    testAllFixtures(script_valid, true);
-    testAllFixtures(script_invalid, false);
+    testAllFixtures(script_tests)
 
   });
-  describe.only('bitcoind transaction evaluation fixtures', function() {
+  describe('bitcoind transaction evaluation fixtures', function() {
     var test_txs = function(set, expected) {
       var c = 0;
-      set.forEach(function(vector) {
+      let label = '';
+      let runIdx = 1;
+      set.forEach(function(vector, vIndex) {
         if (vector.length === 1) {
           return;
         }
         c++;
         var cc = c; //copy to local
-        it('should pass tx_' + (expected ? '' : 'in') + 'valid vector ' + cc, function() {
+        if (set[vIndex - 1].length === 1) {
+          label = set[vIndex - 1][0];
+        }
+        it('should pass tx_' + (expected ? '' : 'in') + 'valid vector ' + cc + ' -- ' + label, function() {
+          if (runIdx == 88) {
+            runIdx;
+          }
+          runIdx++
           var inputs = vector[0];
           var txhex = vector[1];
           var flags = getFlags(vector[2]);
         
 
           var map = {};
+          var mapprevOutValues = {};
           inputs.forEach(function(input) {
             var txid = input[0];
             var txoutnum = input[1];
@@ -324,6 +330,9 @@ describe('Interpreter', function() {
               txoutnum = 0xffffffff; //bitcoind casts -1 to an unsigned int
             }
             map[txid + ':' + txoutnum] = Script.fromBitcoindString(scriptPubKeyStr);
+            if (input.length >= 4) {
+              mapprevOutValues[txid + ':' + txoutnum] = input[3];
+            }
           });
 
           var tx = new Transaction(txhex);
@@ -336,14 +345,14 @@ describe('Interpreter', function() {
             var txidhex = txin.prevTxId.toString('hex');
             var txoutnum = txin.outputIndex;
             var scriptPubkey = map[txidhex + ':' + txoutnum];
+            var amount = mapprevOutValues[txidhex + ':' + txoutnum] || tx.outputAmount;
             should.exist(scriptPubkey);
             (scriptSig !== undefined).should.equal(true);
             var interp = new Interpreter();
 
             var txinWitnesses = txin.getWitnesses() || [];
-            var verified = interp.verify(scriptSig, scriptPubkey, tx, j, flags, txinWitnesses, tx.outputAmount);
+            var verified = interp.verify(scriptSig, scriptPubkey, tx, j, flags, txinWitnesses, amount);
             if (!verified) {
-              console.log(vector);
               allInputsVerified = false;
             }
           });


### PR DESCRIPTION
Most of this is deprecated Buffer changes, but the actual test fix includes allocating `hashPrevouts` and `hashSequence` in `sighashwitness.js`, and the `mapprevOutValues` in `test/interpreter.js`